### PR TITLE
ci: update permissions for workflows to minimal required access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: Build, Test & Release
 
+# Default minimal permissions; jobs elevate only where required.
 permissions:
-  contents: write
-  actions: read
+  contents: read
 
 on:
   push:
@@ -15,6 +15,9 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # read repository contents for checkout
+      actions: write       # needed to upload artifacts (test results)
     
     steps:
     - name: Checkout code
@@ -45,6 +48,8 @@ jobs:
   code-quality:
     name: Code Quality Analysis
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # only needs to read code
     
     steps:
     - name: Checkout code
@@ -73,6 +78,9 @@ jobs:
     strategy:
       matrix:
         runtime: [win-x64, linux-x64, osx-x64]
+    permissions:
+      contents: read       # read code for checkout
+      actions: write       # upload build artifacts
     
     steps:
     - name: Checkout code
@@ -123,6 +131,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: release
     if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write      # create the GitHub release
+      actions: read        # download artifacts
     
     steps:
     - name: Checkout code

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,5 +1,9 @@
 name: Manual Release
 
+# Default minimal permissions; jobs elevate only where required.
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -33,6 +37,9 @@ jobs:
           - target: win-x86
             artifact_name: PartnerAdminLinkTool-win-x86
             asset_name: PartnerAdminLinkTool-win-x86.zip
+    permissions:
+      contents: read   # checkout code
+      actions: write   # upload artifacts
     
     steps:
     - name: Checkout code
@@ -92,6 +99,9 @@ jobs:
     name: Create Manual Release
     needs: manual-release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # create release
+      actions: read    # download artifacts
     
     steps:
     - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release
 
+# Default minimal permissions; specific jobs elevate if needed.
+permissions:
+  contents: read
+
 on:
   push:
     tags:
@@ -29,6 +33,9 @@ jobs:
             os: windows-latest
             artifact_name: PartnerAdminLinkTool-win-x86
             asset_name: PartnerAdminLinkTool-win-x86.exe
+    permissions:
+      contents: read    # checkout code
+      actions: write    # upload artifacts
     
     steps:
     - name: Checkout code
@@ -102,6 +109,9 @@ jobs:
     needs: create-release-artifacts
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write   # create/update release
+      actions: read     # download artifacts
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
This pull request improves the security of all GitHub Actions workflows by setting the minimal required permissions globally and then elevating permissions only for specific jobs as needed. This principle of least privilege reduces the risk of accidental or malicious misuse of workflow tokens.

**Security and Permissions Hardening:**

* Set default minimal permissions (`contents: read`) at the workflow level in `.github/workflows/ci.yml`, `.github/workflows/release.yml`, and `.github/workflows/manual-release.yml`, with comments explaining the change. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR3-R5) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R3-R6) [[3]](diffhunk://#diff-15fb1f5c1e9076ac354d7b3c7a9e3d508e100c550bfbabd66ec943ea883bf0d9R3-R6)
* Added job-specific `permissions` blocks to elevate permissions only where necessary, such as for uploading artifacts (`actions: write`) or creating releases (`contents: write`), across all workflows. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR18-R20) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR51-R52) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR81-R83) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR134-R136) [[5]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R36-R38) [[6]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R112-R114) [[7]](diffhunk://#diff-15fb1f5c1e9076ac354d7b3c7a9e3d508e100c550bfbabd66ec943ea883bf0d9R40-R42) [[8]](diffhunk://#diff-15fb1f5c1e9076ac354d7b3c7a9e3d508e100c550bfbabd66ec943ea883bf0d9R102-R104)